### PR TITLE
Fix: Add script and instruction to download nltk corpora locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Its purpose is to train a model that is saved in a `.joblib` format, which can t
 
 To run the application, kindly first install dependencies via `pip install -r requirements.txt`.
 
+**Important!**
+
+Then, run the following script to make sure needed nltk corpora is installed on your machine:
+
+```bash
+python setup_nltk.py
+```
 ## Usage
 Once the project is ready to run, simply run [`create_model.py`](https://github.com/remla25-team4/model-training/blob/main/model_code/create_model.py) file, which may be found under the [`model_code`](https://github.com/remla25-team4/model-training/blob/main/model_code/) directory. The created model (and the bag of words encoding) will be saved as separate `.joblib` files in the [`models`](https://github.com/remla25-team4/model-training/tree/main/models) folder.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 scikit-learn==1.5.0
 pandas==2.2.0
 numpy==1.26.3
-nltk==3.9
+nltk
 joblib==1.3.2 
 lib-ml @ git+https://github.com/remla25-team4/lib-ml.git@v0.1.0
 pytest

--- a/setup_nltk.py
+++ b/setup_nltk.py
@@ -1,0 +1,14 @@
+import nltk
+
+resources_to_download = ['wordnet', 'stopwords', 'omw-1.4'] # 'omw-1.4' is often needed with wordnet
+
+for resource in resources_to_download:
+    print(f"Attempting to download NLTK '{resource}'...")
+    try:
+        nltk.download(resource, quiet=True)
+        print(f"'{resource}' downloaded successfully or already present.")
+    except Exception as e:
+        print(f"Error downloading '{resource}': {e}")
+        print(f"Please try 'python -m nltk.downloader {resource}' manually in your terminal.")
+
+print("\nNLTK resource download process complete.")


### PR DESCRIPTION
Added a python script that:
- automatically downloads the needed nltk corpora used for data preprocessing if missing on host machine

Added instructions in README.md to running the script.