### PR TITLE
Fix: make all files point to the correct data path

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,38 +1,38 @@
 schema: '2.0'
 stages:
   train:
-    cmd: python3 model_training/training.py
+    cmd: python3 pipeline/training.py
     deps:
-    - path: data/raw/training_dataset.tsv
+    - path: datasets/training_dataset.tsv
       hash: md5
       md5: 262a54e658ab7192e7c22a9ef8eb7909
       size: 61332
-    - path: model_training/training.py
+    - path: pipeline/training.py
       hash: md5
-      md5: f11c321da308dfa69f5b6a9ade0dee7e
-      size: 754
+      md5: 553720725f063aca4d189c378db6c4e8
+      size: 765
     outs:
     - path: models/count_vectorizer.joblib
       hash: md5
-      md5: 141874395ea38cbf49b5f152b09cadd4
-      size: 4301
+      md5: 6ff98517814c7f022f831f526cd61121
+      size: 4300
     - path: models/naive_bayes.joblib
       hash: md5
-      md5: 7b1d2e0e4d677a38dd81b76ee5db5fea
+      md5: 5bc9751723941ee33e3e03d9a87017b8
       size: 5255
   evaluate:
-    cmd: python3 model_training/evaluation.py
+    cmd: python3 pipeline/evaluation.py
     deps:
-    - path: model_training/evaluation.py
-      hash: md5
-      md5: ea896d88fbf0b13c6ebf932255223622
-      size: 768
     - path: models/naive_bayes.joblib
       hash: md5
-      md5: 7b1d2e0e4d677a38dd81b76ee5db5fea
+      md5: 5bc9751723941ee33e3e03d9a87017b8
       size: 5255
+    - path: pipeline/evaluation.py
+      hash: md5
+      md5: c5daf14cbfa34d9e6dfc363ddfe0d485
+      size: 829
     outs:
     - path: metrics/evaluation_metrics.json
       hash: md5
-      md5: cfe552d1a5b0056f71162278084e8082
-      size: 76
+      md5: db06e7537dae3d85e8aef235e4891392
+      size: 75

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -2,7 +2,7 @@ stages:
   train:
     cmd: python3 pipeline/training.py
     deps:
-    - data/raw/training_dataset.tsv
+    - datasets/training_dataset.tsv
     - pipeline/training.py
     outs:
     - models/count_vectorizer.joblib

--- a/metrics/evaluation_metrics.json
+++ b/metrics/evaluation_metrics.json
@@ -1,5 +1,5 @@
 {
-  "accuracy": 0.705,
-  "precision": 0.707948957360722,
-  "recall": 0.705
+  "accuracy": 0.71,
+  "precision": 0.7125754443985118,
+  "recall": 0.71
 }

--- a/pipeline/data_processing.py
+++ b/pipeline/data_processing.py
@@ -22,7 +22,7 @@ def to_bag_of_words(corpus, dataset):
     return X, y
 
 def get_dataset():
-    dataset = pd.read_csv("data/raw/training_dataset.tsv", delimiter='\t')
+    dataset = pd.read_csv("datasets/training_dataset.tsv", delimiter='\t')
     corpus = preprocess_dataset(dataset)
     X, y = to_bag_of_words(corpus, dataset)
     return train_test_split(X, y, test_size=0.20, random_state=42)


### PR DESCRIPTION
Previously, the dvc pipeline points to data/raw/training_dataset.tsv and the pytests to datasets/training_dataset.tsv. Removed this redundancy by making all files that access the data point to the latter path.