### PR TITLE
Add pylint

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,8 +2,6 @@ name: Pylint
 
 on:
   push:
-  pull_request:
-    branches: [ main ]
 
 jobs:
   lint:
@@ -39,7 +37,6 @@ jobs:
         echo "score=$SCORE" >> $GITHUB_OUTPUT
     
     - name: Update README with Pylint Score
-      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main')
       run: |
         # Get score from previous step
         SCORE="${{ steps.pylint.outputs.score }}"
@@ -70,7 +67,6 @@ jobs:
         fi
     
     - name: Commit and push README changes
-      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main')
       run: |
         git config --global user.name 'github-actions'
         git config --global user.email 'github-actions@github.com'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -13,8 +13,8 @@ jobs:
       packages: write
       id-token: write
     steps:
-   - name: Checkout code
-     uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
     
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,77 @@
+name: Pylint
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    steps:
+   - name: Checkout code
+     uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Run Pylint
+      id: pylint
+      run: |
+        # Run pylint and save output to a file
+        pylint pipeline notebooks tests > pylint_output.txt || true
+        
+        # Extract score using grep and sed
+        SCORE=$(grep -o "Your code has been rated at [0-9]\+\.[0-9]\+/10" pylint_output.txt | sed 's/Your code has been rated at \([0-9.]*\)\/10/\1/')
+        
+        # Set score as output variable
+        echo "score=$SCORE" >> $GITHUB_OUTPUT
+    
+    - name: Update README with Pylint Score
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main')
+      run: |
+        # Get score from previous step
+        SCORE="${{ steps.pylint.outputs.score }}"
+        
+        # Determine badge color based on score
+        if (( $(echo "$SCORE >= 9.0" | bc -l) )); then
+          COLOR="brightgreen"
+        elif (( $(echo "$SCORE >= 8.0" | bc -l) )); then
+          COLOR="green"
+        elif (( $(echo "$SCORE >= 7.0" | bc -l) )); then
+          COLOR="yellowgreen"
+        elif (( $(echo "$SCORE >= 6.0" | bc -l) )); then
+          COLOR="yellow"
+        else
+          COLOR="red"
+        fi
+        
+        # Create badge URL
+        BADGE_URL="https://img.shields.io/badge/pylint-${SCORE}%2F10-${COLOR}"
+        
+        # Update README.md
+        if grep -q "!\[Pylint Score\]" README.md; then
+          # Update existing badge
+          sed -i "s|!\[Pylint Score\](https://img.shields.io/badge/pylint-[0-9.]*%2F10-[a-z]*)|![Pylint Score](${BADGE_URL})|g" README.md
+        else
+          # Add badge after first heading
+          sed -i "0,/^# /s/^# \(.*\)$/# \1\n\n![Pylint Score](${BADGE_URL})/" README.md
+        fi
+    
+    - name: Commit and push README changes
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main')
+      run: |
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+        git diff --quiet README.md || (git add README.md && git commit -m "Update Pylint score badge [skip ci]" && git push)

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -60,7 +60,7 @@ jobs:
         # Update README.md
         if grep -q "!\[Pylint Score\]" README.md; then
           # Update existing badge
-          sed -i "s|!\[Pylint Score\](https://img.shields.io/badge/pylint-[0-9.]*%2F10-[a-z]*)|![Pylint Score](${BADGE_URL})|g" README.md
+          sed -i 's|!\[Pylint Score\](https://img\.shields\.io/badge/pylint-[0-9.]*%2F10-[a-z]*)|![Pylint Score]('"${BADGE_URL}"')|g' README.md
         else
           # Add badge after first heading
           sed -i "0,/^# /s/^# \(.*\)$/# \1\n\n![Pylint Score](${BADGE_URL})/" README.md

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -35,7 +35,13 @@ jobs:
         
         # Set score as output variable
         echo "score=$SCORE" >> $GITHUB_OUTPUT
-    
+        
+    - name: Upload Pylint Output
+      uses: actions/upload-artifact@v3
+      with:
+        name: pylint-results
+        path: pylint_output.txt
+
     - name: Update README with Pylint Score
       run: |
         # Get score from previous step

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -35,9 +35,9 @@ jobs:
         
         # Set score as output variable
         echo "score=$SCORE" >> $GITHUB_OUTPUT
-        
+
     - name: Upload Pylint Output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pylint-results
         path: pylint_output.txt

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -54,16 +54,26 @@ jobs:
           COLOR="red"
         fi
         
-        # Create badge URL
-        BADGE_URL="https://img.shields.io/badge/pylint-${SCORE}%2F10-${COLOR}"
+        # Create badge markdown
+        BADGE="![Pylint Score](https://img.shields.io/badge/pylint-${SCORE}%2F10-${COLOR})"
         
         # Update README.md
         if grep -q "!\[Pylint Score\]" README.md; then
-          # Update existing badge
-          sed -i 's|!\[Pylint Score\](https://img\.shields\.io/badge/pylint-[0-9.]*%2F10-[a-z]*)|![Pylint Score]('"${BADGE_URL}"')|g' README.md
+          # Create a new file with the badge replaced
+          perl -pe 's|!\[Pylint Score\]\(https://img\.shields\.io/badge/pylint-[\d.]+%2F10-[a-z]+\)|'"$BADGE"'|g' README.md > README.new
+          mv README.new README.md
         else
-          # Add badge after first heading
-          sed -i "0,/^# /s/^# \(.*\)$/# \1\n\n![Pylint Score](${BADGE_URL})/" README.md
+          # Find the first heading line number
+          FIRST_HEADING=$(grep -n "^# " README.md | head -1 | cut -d: -f1)
+          
+          # Create a new file with the badge inserted after the first heading
+          {
+            head -n "$FIRST_HEADING" README.md
+            echo ""
+            echo "$BADGE"
+            tail -n +"$((FIRST_HEADING+1))" README.md
+          } > README.new
+          mv README.new README.md
         fi
     
     - name: Commit and push README changes

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,370 @@
+[MAIN]
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=venv
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.git/
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=LF
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+output-format=github
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # model-training
 
+![Pylint Score](https://img.shields.io/badge/pylint-5.12%2F10-red)
+
 ## Overview
 
 This repo contains the training pipeline for the Sentiment Analysis model

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,6 @@ pytest>=8.3.5
 pyarrow>=20.0.0
 dvc
 dvc-gdrive
+pylint>=2.17.0
 
 


### PR DESCRIPTION
Added pylint to the model-training repo:
- checks folders: pipeline, notebooks, tests
- config is set in .pylintrc
- Added a github workflow that runs pylint after every push + adds pylint score to README
- pylint output is added as an artifact to the workflow run for more detailed feedback
- TODO: improve the pylint score by adressing the warnings (Maybe some rules can be removed from the .pylintrc)